### PR TITLE
improve datetime regexps

### DIFF
--- a/php-export-data.class.php
+++ b/php-export-data.class.php
@@ -198,7 +198,7 @@ class ExportDataExcel extends ExportData {
 		return $output;
 	}
 	
-	private function generateCell($item) {
+	protected function generateCell($item) {
 		$output = '';
 		$style = '';
 		
@@ -211,7 +211,14 @@ class ExportDataExcel extends ExportData {
 		// Note we want to be very strict in what we consider a date. There is the possibility
 		// of really screwing up the data if we try to reformat a string that was not actually 
 		// intended to represent a date.
-		elseif(preg_match("/^(\d{1,2}|\d{4})[\/\-]\d{1,2}[\/\-](\d{1,2}|\d{4})([^\d].+)?$/",$item) &&
+		elseif (preg_match('_^
+				# dates: 2010-07-14 or 7/14/2010
+				(?:\d{1,2}|\d{4})[/-]\d{1,2}[/-](?:\d{1,2}|\d{4})
+				# optional time
+				(?:[T\s]+ # separated by space or T
+				[\d:,]+ # hours:minutes
+				)?
+				$_x', $item) &&
 					($timestamp = strtotime($item)) &&
 					($timestamp > 0) &&
 					($timestamp < strtotime('+500 years'))) {

--- a/test/ExportDataExcelTest.php
+++ b/test/ExportDataExcelTest.php
@@ -1,0 +1,54 @@
+<?php
+require_once dirname(__FILE__) . '/../php-export-data.class.php';
+
+class ExportDataExcelWrap extends ExportDataExcel {
+	public function wrapGenerateCell($item) {
+		return $this->generateCell($item);
+	}
+}
+
+/**
+ *
+ */
+class ExportDataExcelTest extends PHPUnit_Framework_TestCase {
+	protected $output = 'browser';
+	/**
+	 * @var ExportDataExcel
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture
+	 */
+	protected function setUp() {
+		$this->object = new ExportDataExcelWrap($this->output);
+	}
+
+	/**
+	 * @covers ExportDataExcel::generateCell
+	 * @dataProvider dateProvider
+	 */
+	public function testDates($exp, $date) {
+		$res = $this->object->wrapGenerateCell($date);
+		$this->assertNotEmpty($res);
+		$res = trim($res);
+		$this->assertEquals($exp, $res);
+	}
+
+	public function dateProvider() {
+		return array(
+			// iso dates: https://en.wikipedia.org/wiki/ISO_8601
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T00:00:00</Data></Cell>',"2010-01-02"),
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T09:52:00</Data></Cell>', "2010-01-02 9:52"),
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T10:00:00</Data></Cell>', "2010-01-02T10:00"),
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T10:00:00</Data></Cell>', "2010-01-02T10:00:00"),
+			# microseconds not supported by strtotime
+#			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T06:12:00</Data></Cell>', "2010-01-02T06:12:00,000"),
+#			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-01-02T00:00:00</Data></Cell>', "2010-01-02T10:00:00,000"),
+			// US dates
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-02-08T00:00:00</Data></Cell>', "02/08/2010 00:00"),
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-02-08T00:00:00</Data></Cell>', "02/08/2010"),
+			array('<Cell ss:StyleID="sDT"><Data ss:Type="DateTime">2010-02-09T00:00:00</Data></Cell>', "2/9/2010"),
+		);
+	}
+}


### PR DESCRIPTION
based on discussion from here:
https://github.com/elidickinson/php-export-data/commit/c00f622d24f833c35b6a45d89dd49098865b41ee#commitcomment-1887500

it seemed strtotime() does not support microseconds, so i left that out

also your file encoding was MSDOS based, and weird file execute bits on files. you might want to fixup that. did not want to do it in my commit, as that would make whole diff unreadable

also for the sake of testing, i made one method protected instead of private, and i noticed some other methods access is not defined at all (indeed that defaults to "public") would be nice to clean those up as well.

so included phpunit test for the date thing only
